### PR TITLE
fix reduce order and crash when all deps are empty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,15 +45,13 @@ export async function createDeps({ cwd }) {
       const pkg = pkgPath ? await readPackage({ cwd: pkgPath }) : await packageJson(value, { fullMetadata: true })
 
       return {
-        ...{
-          [value]: {
-            homepage: homepageToString(pkg.homepage),
-            npm: `https://www.npmjs.com/package/${pkg.name}`,
-            repository: repositoryToString(pkg.repository ? pkg.repository.url : undefined),
-            version: pkg.version,
-          },
-        },
         ...prevValue,
+        [value]: {
+          homepage: homepageToString(pkg.homepage),
+          npm: `https://www.npmjs.com/package/${pkg.name}`,
+          repository: repositoryToString(pkg.repository ? pkg.repository.url : undefined),
+          version: pkg.version,
+        },
       }
     }, Promise.resolve({}))
   }
@@ -83,39 +81,27 @@ export async function createDeps({ cwd }) {
 export function depsToString(deps) {
   const INDENT = 2
   const PADDING = 2
+  const nonEmptyDeps = Object.entries(deps).filter(([, dep]) => Object.keys(dep).length > 0)
+  if (nonEmptyDeps.length === 0) {
+    return ''
+  }
   const maxDepsNameLength = Math.max.apply(
     null,
-    Object.entries(deps).map(([depsName, dep]) =>
-      Math.max.apply(
-        null,
-        Object.keys(dep).map((pkgName) => pkgName.length)
-      )
-    )
+    nonEmptyDeps.map(([, dep]) => Math.max.apply(null, Object.keys(dep).map((pkgName) => pkgName.length)))
   )
   const maxVersionLength = Math.max.apply(
     null,
-    Object.entries(deps).map(([depsName, dep]) =>
-      Math.max.apply(
-        null,
-        Object.entries(dep).map(([pkgName, pkgSummary]) => pkgSummary.version.length)
-      )
-    )
+    nonEmptyDeps.map(([, dep]) => Math.max.apply(null, Object.entries(dep).map(([, pkgSummary]) => pkgSummary.version.length)))
   )
   const maxNpmLength = Math.max.apply(
     null,
-    Object.entries(deps).map(([depsName, dep]) =>
-      Math.max.apply(
-        null,
-        Object.entries(dep).map(([pkgName, pkgSummary]) => pkgSummary.npm.length)
-      )
-    )
+    nonEmptyDeps.map(([, dep]) => Math.max.apply(null, Object.entries(dep).map(([, pkgSummary]) => pkgSummary.npm.length)))
   )
   const spaceToString = (repeat) => ' '.repeat(repeat)
   const versionIndentToString = (pkgName) => spaceToString(maxDepsNameLength - pkgName.length + PADDING)
   const urlIndentToString = (version) => spaceToString(maxVersionLength - version.length + PADDING)
 
-  return Object.entries(deps)
-    .filter(([depsName, dep]) => Object.keys(dep).length)
+  return nonEmptyDeps
     .map(
       ([depsName, dep]) =>
         `\n${spaceToString(INDENT)}${chalk.green.bold(depsName)}\n${Object.entries(dep)

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`createDeps 1`] = `
+[
+  "chalk",
+  "core-js",
+  "package-json",
+  "path-exists",
+  "read-pkg",
+  "yargs",
+]
+`;
+
 exports[`depsToString 1`] = `
 {
   "bundleDependencies": {},

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,7 @@ it('createDeps', async () => {
   expect(deps.optionalDependencies).toBeTruthy()
   expect(deps.bundleDependencies).toBeTruthy()
   expect(deps.bundledDependencies).toBeTruthy()
+  expect(Object.keys(deps.dependencies)).toMatchSnapshot()
 })
 
 it('depsToString', async () => {
@@ -126,4 +127,16 @@ it('depsToString', async () => {
   expect(deps).toMatchSnapshot()
   const depsString = await depsToString(deps)
   expect(stripAnsi(depsString)).toMatchSnapshot()
+})
+
+it('depsToString returns empty string when all deps are empty', () => {
+  const deps = {
+    dependencies: {},
+    devDependencies: {},
+    peerDependencies: {},
+    optionalDependencies: {},
+    bundleDependencies: {},
+    bundledDependencies: {},
+  }
+  expect(depsToString(deps)).toBe('')
 })


### PR DESCRIPTION
## Summary

- Fix object spread order in `reduce` — `prevValue` was spread last, causing it to overwrite accumulated entries
- Fix crash in `depsToString` when all deps are empty — `Math.max()` returned `-Infinity`, causing `' '.repeat()` to throw; now returns early with `''` if no non-empty deps exist
- Reuse `nonEmptyDeps` in the render step to avoid redundant filtering

## Test plan

- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)