### PR TITLE
improve test coverage for createDeps values and depsToString url patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ dist
 
 
 !test/fixtures
+!test/fixtures-local/node_modules
+!test/fixtures-local/node_modules/**

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,14 +1,44 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`createDeps 1`] = `
-[
-  "chalk",
-  "core-js",
-  "package-json",
-  "path-exists",
-  "read-pkg",
-  "yargs",
-]
+{
+  "chalk": {
+    "homepage": "https://github.com/chalk/chalk",
+    "npm": "https://www.npmjs.com/package/chalk",
+    "repository": "https://github.com/chalk/chalk",
+    "version": "5.6.2",
+  },
+  "core-js": {
+    "homepage": "https://core-js.io/",
+    "npm": "https://www.npmjs.com/package/core-js",
+    "repository": "https://github.com/zloirock/core-js",
+    "version": "3.49.0",
+  },
+  "package-json": {
+    "homepage": "https://github.com/sindresorhus/package-json",
+    "npm": "https://www.npmjs.com/package/package-json",
+    "repository": "https://github.com/sindresorhus/package-json",
+    "version": "10.0.1",
+  },
+  "path-exists": {
+    "homepage": "https://github.com/sindresorhus/path-exists",
+    "npm": "https://www.npmjs.com/package/path-exists",
+    "repository": "https://github.com/sindresorhus/path-exists",
+    "version": "5.0.0",
+  },
+  "read-pkg": {
+    "homepage": "https://github.com/sindresorhus/read-pkg",
+    "npm": "https://www.npmjs.com/package/read-pkg",
+    "repository": "https://github.com/sindresorhus/read-pkg",
+    "version": "10.1.0",
+  },
+  "yargs": {
+    "homepage": "https://yargs.js.org/",
+    "npm": "https://www.npmjs.com/package/yargs",
+    "repository": "https://github.com/yargs/yargs",
+    "version": "18.0.0",
+  },
+}
 `;
 
 exports[`depsToString 1`] = `
@@ -141,4 +171,12 @@ exports[`depsToString 2`] = `
   rimraf                    3.0.2    https://www.npmjs.com/package/rimraf                    https://github.com/isaacs/rimraf
   strip-ansi                7.0.0    https://www.npmjs.com/package/strip-ansi                https://github.com/chalk/strip-ansi
   typescript                4.3.5    https://www.npmjs.com/package/typescript                https://www.typescriptlang.org/"
+`;
+
+exports[`depsToString url display patterns 1`] = `
+"
+  dependencies
+  with-homepage     1.0.0  https://www.npmjs.com/package/with-homepage     https://example.com
+  without-homepage  1.0.0  https://www.npmjs.com/package/without-homepage  https://github.com/example/without-homepage
+  without-urls      1.0.0  https://www.npmjs.com/package/without-urls      "
 `;

--- a/test/fixtures-local/node_modules/local-pkg/package.json
+++ b/test/fixtures-local/node_modules/local-pkg/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "local-pkg",
+  "version": "1.2.3",
+  "homepage": "https://example.com/local-pkg",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/example/local-pkg.git"
+  }
+}

--- a/test/fixtures-local/package.json
+++ b/test/fixtures-local/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixtures-local",
+  "version": "1.0.0",
+  "dependencies": {
+    "local-pkg": "1.2.3"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ it('createDeps', async () => {
   expect(deps.optionalDependencies).toBeTruthy()
   expect(deps.bundleDependencies).toBeTruthy()
   expect(deps.bundledDependencies).toBeTruthy()
-  expect(Object.keys(deps.dependencies)).toMatchSnapshot()
+  expect(deps.dependencies).toMatchSnapshot()
 })
 
 it('depsToString', async () => {
@@ -127,6 +127,37 @@ it('depsToString', async () => {
   expect(deps).toMatchSnapshot()
   const depsString = await depsToString(deps)
   expect(stripAnsi(depsString)).toMatchSnapshot()
+})
+
+it('depsToString url display patterns', () => {
+  const deps = {
+    dependencies: {
+      'with-homepage': {
+        homepage: 'https://example.com',
+        npm: 'https://www.npmjs.com/package/with-homepage',
+        repository: 'https://github.com/example/with-homepage',
+        version: '1.0.0',
+      },
+      'without-homepage': {
+        homepage: '',
+        npm: 'https://www.npmjs.com/package/without-homepage',
+        repository: 'https://github.com/example/without-homepage',
+        version: '1.0.0',
+      },
+      'without-urls': {
+        homepage: '',
+        npm: 'https://www.npmjs.com/package/without-urls',
+        repository: '',
+        version: '1.0.0',
+      },
+    },
+    devDependencies: {},
+    peerDependencies: {},
+    optionalDependencies: {},
+    bundleDependencies: {},
+    bundledDependencies: {},
+  }
+  expect(stripAnsi(depsToString(deps))).toMatchSnapshot()
 })
 
 it('depsToString returns empty string when all deps are empty', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,18 @@ import stripAnsi from 'strip-ansi'
 import { fileURLToPath } from 'node:url'
 import { createDeps, depsToString } from '../lib/index.js'
 
+it('createDeps reads package info from local node_modules', async () => {
+  const deps = await createDeps({
+    cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'fixtures-local'),
+  })
+  expect(deps.dependencies['local-pkg']).toEqual({
+    homepage: 'https://example.com/local-pkg',
+    npm: 'https://www.npmjs.com/package/local-pkg',
+    repository: 'https://github.com/example/local-pkg',
+    version: '1.2.3',
+  })
+})
+
 it('createDeps', async () => {
   const deps = await createDeps({
     cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'fixtures'),


### PR DESCRIPTION
## Summary

- Expand `createDeps` snapshot to cover full package values (homepage, npm, repository, version) instead of just key names
- Add `depsToString url display patterns` test covering three cases: homepage set, homepage empty with repository, both empty

## Test plan

- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)