### PR TITLE
Refactor for Node.js 22: use built-in globals and node: imports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,13 @@
-import { URL } from 'url'
 import chalk from 'chalk'
-import Module from 'module'
 import packageJson from 'package-json'
-import path from 'path'
-import { pathExistsSync } from 'path-exists'
+import path from 'node:path'
+import { existsSync } from 'node:fs'
 import { readPackage } from 'read-pkg'
 
 function getPackagePath(pkgName, options) {
   const cwd = options && options.cwd ? options.cwd : process.cwd()
-  const nodeModulesPaths = Module._nodeModulePaths(cwd)
-  const packagePath = path.join(nodeModulesPaths[0], pkgName)
-  if (pathExistsSync(packagePath)) {
+  const packagePath = path.join(cwd, 'node_modules', pkgName)
+  if (existsSync(packagePath)) {
     return packagePath
   }
 }
@@ -85,17 +82,14 @@ export function depsToString(deps) {
   if (nonEmptyDeps.length === 0) {
     return ''
   }
-  const maxDepsNameLength = Math.max.apply(
-    null,
-    nonEmptyDeps.map(([, dep]) => Math.max.apply(null, Object.keys(dep).map((pkgName) => pkgName.length)))
+  const maxDepsNameLength = Math.max(
+    ...nonEmptyDeps.map(([, dep]) => Math.max(...Object.keys(dep).map((pkgName) => pkgName.length)))
   )
-  const maxVersionLength = Math.max.apply(
-    null,
-    nonEmptyDeps.map(([, dep]) => Math.max.apply(null, Object.entries(dep).map(([, pkgSummary]) => pkgSummary.version.length)))
+  const maxVersionLength = Math.max(
+    ...nonEmptyDeps.map(([, dep]) => Math.max(...Object.entries(dep).map(([, pkgSummary]) => pkgSummary.version.length)))
   )
-  const maxNpmLength = Math.max.apply(
-    null,
-    nonEmptyDeps.map(([, dep]) => Math.max.apply(null, Object.entries(dep).map(([, pkgSummary]) => pkgSummary.npm.length)))
+  const maxNpmLength = Math.max(
+    ...nonEmptyDeps.map(([, dep]) => Math.max(...Object.entries(dep).map(([, pkgSummary]) => pkgSummary.npm.length)))
   )
   const spaceToString = (repeat) => ' '.repeat(repeat)
   const versionIndentToString = (pkgName) => spaceToString(maxDepsNameLength - pkgName.length + PADDING)
@@ -105,15 +99,7 @@ export function depsToString(deps) {
     .map(
       ([depsName, dep]) =>
         `\n${spaceToString(INDENT)}${chalk.green.bold(depsName)}\n${Object.entries(dep)
-          .sort((a, b) => {
-            if (a[0] < b[0]) {
-              return -1
-            }
-            if (a[0] > b[0]) {
-              return 1
-            }
-            return 0
-          })
+          .sort((a, b) => a[0].localeCompare(b[0]))
           .map(([pkgName, { homepage, repository, version, npm }]) => {
             return `${spaceToString(INDENT)}${pkgName}${versionIndentToString(pkgName)}${chalk.gray(
               version

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
-        "core-js": "^3.15.2",
         "package-json": "^10.0.0",
-        "path-exists": "^5.0.0",
         "read-pkg": "^10.0.0",
         "yargs": "^18.0.0"
       },
@@ -1356,16 +1354,6 @@
         "proto-list": "~1.2.1"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1931,14 +1919,6 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
-    },
-    "node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -3752,11 +3732,6 @@
         "proto-list": "~1.2.1"
       }
     },
-    "core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="
-    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4148,11 +4123,6 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
-    },
-    "path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
     },
     "path-key": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   },
   "dependencies": {
     "chalk": "^5.0.0",
-    "core-js": "^3.15.2",
     "package-json": "^10.0.0",
-    "path-exists": "^5.0.0",
     "read-pkg": "^10.0.0",
     "yargs": "^18.0.0"
   },


### PR DESCRIPTION
## Summary

- Remove `import { URL } from 'url'` — `URL` is a global since Node.js 10
- Replace `Module._nodeModulePaths()` (private API) with direct `path.join(cwd, 'node_modules', pkgName)`
- Replace `path-exists` dependency with native `existsSync` from `node:fs`
- Add `node:` prefix to built-in imports (`node:path`, `node:fs`)
- Simplify `Math.max.apply(null, arr)` → `Math.max(...arr)`
- Simplify string sort comparator → `localeCompare`
- Remove unused `core-js` and `path-exists` dependencies from `package.json`

## Test plan

- [x] `npm test` passes (all 5 tests)
- [x] `npm run coverage` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)